### PR TITLE
Исправление блокировки в stop()

### DIFF
--- a/src/GyverPlanner.h
+++ b/src/GyverPlanner.h
@@ -139,12 +139,12 @@ public:
                 pause();        // значит флаг на паузу
                 return;
             }
-            status = 4;
             us <<= shift;
             stopStep = 1000000ul / us;                              // наша скорость
             stopStep = (uint32_t)stopStep * stopStep / (2 * a);     // дистанция остановки
             us10 = (uint32_t)us << 10;
             us >>= shift;
+            status = 4;
         }
     }
 


### PR DESCRIPTION
При тактировании из прерывания возникал момент, когда при вызове stop() происходила резкая остановка двигателей. Это связано с тем, что из прерывания вызывалась функция tickManual() в момент, когда в функции stop() переменная status уже изменена на 4, а переменная stopStep ещё не посчитана. В результате tickManual() начинала отработку торможения с неверными данными и сразу вызывала brake().